### PR TITLE
Support hashes with symbol keys

### DIFF
--- a/lib/stub_env/helpers.rb
+++ b/lib/stub_env/helpers.rb
@@ -14,6 +14,7 @@ module StubEnv
     STUBBED_KEY = '__STUBBED__'
 
     def add_stubbed_value(key, value)
+      key = key.to_s
       allow(ENV).to receive(:[]).with(key).and_return(value)
       allow(ENV).to receive(:fetch).with(key).and_return(value)
       allow(ENV).to receive(:fetch).with(key, anything()) do |_, default_val|


### PR DESCRIPTION
Enable simple expressions like:
```ruby
stub_env(key: value)
```

This change assumes that keys are always accessed as strings.